### PR TITLE
Changed get API key to current start page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please visit https://github.com/chainkit/ for the latest and greatest quickstart
 ## Getting Credentials
 
 If you need a username and password for testing it out, visit
-https://chainkit.com/get-api-key 
+https://chainkit.com/start 
 
 You can also email us at: support@pencildata.com for more information
 on our products.


### PR DESCRIPTION
was chainkit.com/get-api-key but on current site it is chainkit.com/start